### PR TITLE
Use groupName to separate account notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@headlessui/react": "^1.2.0",
     "@heroicons/react": "^1.0.0",
     "@jup-ag/react-hook": "^1.0.0-beta.16",
-    "@notifi-network/notifi-react-hooks": "^0.3.0",
+    "@notifi-network/notifi-react-hooks": "^0.4.0",
     "@project-serum/serum": "0.13.55",
     "@project-serum/sol-wallet-adapter": "0.2.0",
     "@solana/web3.js": "^1.31.0",
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "^4.1.0",
-    "@notifi-network/notifi-core": "^0.3.0",
+    "@notifi-network/notifi-core": "^0.4.0",
     "@svgr/webpack": "^6.1.2",
     "@testing-library/react": "^11.2.5",
     "@types/jest": "^26.0.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,22 +1593,22 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@notifi-network/notifi-axios-adapter@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-adapter/-/notifi-axios-adapter-0.3.0.tgz#5c73de604522ec18c9a4f87c6ccad733ef00c446"
-  integrity sha512-lAmY4GMb1mn44JUmil8jn6qUYuMzQUAsUw4Q6XC0uRJGPdAnrKTx8vghgpN04BTNir7cSsiVs8tqBQPt1QAslg==
+"@notifi-network/notifi-axios-adapter@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-adapter/-/notifi-axios-adapter-0.4.0.tgz#d4e38cc234e151c679918f3be8323cec88aab3be"
+  integrity sha512-dQ1HeSH1tqsud8F6GbSy2w9LL/wONUl5ISLjM5osIoeKtULQ33dQhsa4OAaKcO1J9+2zChbHe2u68S4bi44ZVA==
 
-"@notifi-network/notifi-core@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-core/-/notifi-core-0.3.0.tgz#0691865a39f20d27254e253feb9125873338f9ab"
-  integrity sha512-ySL8faida7kAkxoPHfJJot6fCucY3dU+sy6ZB1Z3gi+WSKHHfqXRNjOc61KoeAoEARNoS9ksmgSXmepjNErT9A==
+"@notifi-network/notifi-core@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-core/-/notifi-core-0.4.0.tgz#131f7931cf5a7f303cf5d396b7e4b0ad0b8fc1fc"
+  integrity sha512-GWBx7chiw0SP1tYejA2rDdWLCNo4k/XFfTikuLv3q9CRWl7NAzECj3AvL+RtFZrv9FSy13CDY7c3YSjQ4MvAKg==
 
-"@notifi-network/notifi-react-hooks@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-react-hooks/-/notifi-react-hooks-0.3.0.tgz#57000b0e42dd68a611afb1a715f944e9d982d722"
-  integrity sha512-g5v5j4OQBOs788HQ298KNUXe4o8GS536IK41EpCXQScaMnZsBIzKagN6tZFk+QLCHXmGjbmcX2vA2EHZWFdAAw==
+"@notifi-network/notifi-react-hooks@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-react-hooks/-/notifi-react-hooks-0.4.0.tgz#658ff95df07f922bdba72b694728ca72d5e5bcb5"
+  integrity sha512-tToTwyiqwKpDrqROGdCSV+TJE0t+nR1uRE6J3PgihYb5ogh+ZzpUx0Dwxhg/kByVz46Pt8Kx5xt2LaCwxsZkOg==
   dependencies:
-    "@notifi-network/notifi-axios-adapter" "^0.3.0"
+    "@notifi-network/notifi-axios-adapter" "^0.4.0"
     axios "^0.26.0"
     typedoc-plugin-missing-exports "^0.22.6"
     typescript "^4.5.5"


### PR DESCRIPTION
Mango allows a single user to have multiple accounts, which all manage alerts separately.

We'll log in to Notifi with the program ID and the wallet ID, and then filter
alerts on the client-side with groupName on the alert