### PR TITLE
Update SDK

### DIFF
--- a/components/CreateAlertModal.tsx
+++ b/components/CreateAlertModal.tsx
@@ -16,6 +16,7 @@ import {
   BlockchainEnvironment,
   GqlError,
   useNotifiClient,
+  isAlertObsolete,
 } from '@notifi-network/notifi-react-hooks'
 
 interface CreateAlertModalProps {
@@ -85,7 +86,7 @@ const CreateAlertModal: FunctionComponent<CreateAlertModalProps> = ({
     setLoading(false)
   }
 
-  const { sources } = data || {}
+  const { sources, alerts } = data || {}
 
   const sourceToUse: Source | undefined = useMemo(() => {
     return sources?.find((it) => {
@@ -145,6 +146,7 @@ const CreateAlertModal: FunctionComponent<CreateAlertModalProps> = ({
           phoneNumber: phone.length < 12 ? null : phone,
           telegramId: null,
           filterOptions: {
+            alertFrequency: 'SINGLE',
             threshold: healthInt,
           },
         })
@@ -257,6 +259,17 @@ const CreateAlertModal: FunctionComponent<CreateAlertModalProps> = ({
   useEffect(() => {
     actions.loadAlerts(mangoAccount.publicKey)
   }, [])
+
+  // Delete notifi Alerts that have fired
+  useEffect(() => {
+    const firedAlert = alerts?.find(isAlertObsolete)
+
+    if (firedAlert !== undefined && firedAlert.id !== null) {
+      deleteAlert({ alertId: firedAlert.id }).then(() => {
+        console.log('Successfully deleted notifi alert')
+      })
+    }
+  }, [alerts, deleteAlert])
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@headlessui/react": "^1.2.0",
     "@heroicons/react": "^1.0.0",
     "@jup-ag/react-hook": "^1.0.0-beta.16",
-    "@notifi-network/notifi-react-hooks": "^0.6.1",
+    "@notifi-network/notifi-react-hooks": "^0.8.0",
     "@project-serum/serum": "0.13.55",
     "@project-serum/sol-wallet-adapter": "0.2.0",
     "@solana/wallet-adapter-wallets": "^0.15.5",
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "^4.1.0",
-    "@notifi-network/notifi-core": "^0.6.0",
+    "@notifi-network/notifi-core": "^0.8.0",
     "@svgr/webpack": "^6.1.2",
     "@testing-library/react": "^11.2.5",
     "@types/jest": "^26.0.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,30 +1668,30 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@notifi-network/notifi-axios-adapter@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-adapter/-/notifi-axios-adapter-0.6.1.tgz#19adfd0ee6823ff9998712a42a728a2fb03ee569"
-  integrity sha512-pT9a7hxpsQwng0mYSfBPDEZVWFqDEx0Dh3mQxm2IGz3k0LeAYWV5ktfgwWkUFEAapQ7tYGVJOgi/7vVzjoC4cQ==
+"@notifi-network/notifi-axios-adapter@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-adapter/-/notifi-axios-adapter-0.8.0.tgz#93afbb328473effb23575a5505e94f415091fa47"
+  integrity sha512-pVuKdTGMmw/EejvnEP2CiO/Zmbka6JtX6npMVpf8Lpr6ojANPIBFNt8VfBvpmTJ6kIOTY74dznGpw6hOvENWvQ==
   dependencies:
-    "@notifi-network/notifi-axios-utils" "^0.6.0"
+    "@notifi-network/notifi-axios-utils" "^0.8.0"
 
-"@notifi-network/notifi-axios-utils@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-utils/-/notifi-axios-utils-0.6.0.tgz#1c0f358c6537547d3f2cc023d30ce858fea0fb49"
-  integrity sha512-LXtQYpAlrUHp/beIpVwxgutjINxDszvmaH7OLOJktUQ2uRXog14qJI3hsFRGa7rdCHRkEcE+l5eU92jrUEaW5A==
+"@notifi-network/notifi-axios-utils@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-axios-utils/-/notifi-axios-utils-0.8.0.tgz#83ac4a649ee9facbd32a8d121748bb5c827f9c4f"
+  integrity sha512-q+RDUZ2gRkLl0gfKy6pVQrZHe9fGwLa+zH1Fy+dm3U6SCyAZX8cjqiLpFLYVJE89nguMMc28tnp3T5K39+wBlQ==
 
-"@notifi-network/notifi-core@^0.6.1":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-core/-/notifi-core-0.6.0.tgz#5c5d7fdb6beb044a634a320ca72900c986d09a71"
-  integrity sha512-WtlpkQeNf/biSIk4iQpeq4HhngmtF2xY+YFKA4OlOH7aloDONs0kJH3RRlYjWl7Sm2Ikr9u8yIqXRC6aVf+GQQ==
+"@notifi-network/notifi-core@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-core/-/notifi-core-0.8.0.tgz#e3a3eed8a6e2995d75a736239959bf42bbf32fe1"
+  integrity sha512-az+ux5QhvBS+AZnjb9+RBuzh0MWWOIUdmpVzOiNazBxX1O1XVnokfaCImeTpYpe7eEoAvwOLirTnFMsfvF0gdQ==
 
-"@notifi-network/notifi-react-hooks@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-react-hooks/-/notifi-react-hooks-0.6.1.tgz#75753c68f17bb0c074cc967d1fb2c3bb0754c02e"
-  integrity sha512-ESgz8zksqE+jQp8BDXvS/WCKpYQhAtDE1tXTkX67yGDgH0UvIJ6f+zz/3KOcYRMWDktEIxQqlUuQkhBHYMKM8g==
+"@notifi-network/notifi-react-hooks@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@notifi-network/notifi-react-hooks/-/notifi-react-hooks-0.8.0.tgz#6bb43789396d8596d7be97c0cd64fdc67de172f9"
+  integrity sha512-UzmsY8MdeOWXIU8vsfhdl6DhHSgzicDp304ZjxjKxGapBpzUH+1E4OS3J2BHH/OCbvP59BoCfujskIbkOCY5VA==
   dependencies:
-    "@notifi-network/notifi-axios-adapter" "^0.6.1"
-    "@notifi-network/notifi-axios-utils" "^0.6.0"
+    "@notifi-network/notifi-axios-adapter" "^0.8.0"
+    "@notifi-network/notifi-axios-utils" "^0.8.0"
     axios "^0.26.0"
     typedoc-plugin-missing-exports "^0.22.6"
     typescript "^4.5.5"


### PR DESCRIPTION
The SDK upgrades support for filterFrequency.

One shot alerts will be marked inside FilterOptions with a
`delayProcessingUntil` field. When the client recognizes these, it
should feel comfortable deleting them, since they should have triggered
already.